### PR TITLE
Remove GOMAXPROCS

### DIFF
--- a/cmd/manael/main.go
+++ b/cmd/manael/main.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"runtime"
 
 	"github.com/gorilla/handlers"
 	"manael.org/x/manael"
@@ -18,8 +17,6 @@ var upstreamURL = flag.String("upstream-url", "http://localhost:9000", "")
 
 func main() {
 	flag.Parse()
-
-	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	h := &manael.Handler{
 		UpstreamURL: *upstreamURL,


### PR DESCRIPTION
> By default, Go programs run with GOMAXPROCS set to the number of cores available; in prior releases it defaulted to 1.

**cite:** [Go 1.5 Release Notes - The Go Programming Language](https://golang.org/doc/go1.5)