### PR TITLE
chore(devcontainer): update Go image and document yarn.list workaround

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,9 @@
-FROM mcr.microsoft.com/devcontainers/go:1-1.23-bookworm@sha256:35e445a87924ae04c171d7e52e2a913050dfefbacda3756ef7a307db035704d5
+FROM mcr.microsoft.com/devcontainers/go:2.0.8-1.25-bookworm@sha256:65af278fcedeef06eb6b672ad4a95c95cf0849cb82d4852ff014719fe6cdf262
+
+# Workaround for devcontainers/images#1797:
+# stale Yarn APT source can cause "apt-get update" to fail with NO_PUBKEY.
+RUN rm -f /etc/apt/sources.list.d/yarn.list
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends libaom-dev libwebp-dev
+    && apt-get -y install --no-install-recommends libvips-dev

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,7 @@
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {
     "ghcr.io/devcontainers/features/node:1.7.1": {
-      "version": "24.14"
+      "version": "24.14.0"
     }
   },
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 /website/public/
 /website/resources/
 
+/go.work.sum
+
 /yarn-error.log
 website/package-lock.json
 /manael


### PR DESCRIPTION
## Summary
- update devcontainer base image to mcr.microsoft.com/devcontainers/go:2.0.8-1.25-bookworm (pinned digest)
- remove yarn.list before apt-get update as workaround for devcontainers/images#1797
- switch devcontainer apt package to libvips-dev
- update Node feature version to 24.14.0
- ignore go.work.sum to avoid committing workspace-specific checksum files

## Notes
- yarn.list removal is defensive (rm -f) and prevents intermittent apt-get update failures caused by Yarn repo key issues.
- go.work.sum is intentionally excluded based on Go modules guidance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment to newer runtime/tool versions for improved build stability.
  * Adjusted package sources and system dependency set to avoid installation issues.
  * Fine-tuned node feature version used by the environment.
  * Added workspace metadata to ignore list to reduce clutter in version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->