### PR TITLE
build: keep go.mod go directive pinned to 1.24.0

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,12 +24,16 @@
   "lockFileMaintenance": {
     "extends": [":semanticCommitType(build)"]
   },
-  "platformAutomerge": true,
-  "postUpdateOptions": [
-    "gomodTidy",
-    "gomodUpdateImportPaths",
-    "pnpmDedupe"
+  "packageRules": [
+    {
+      "description": "Keep go.mod language version pinned for CI floor",
+      "matchManagers": ["gomod"],
+      "matchDatasources": ["golang-version"],
+      "enabled": false
+    }
   ],
+  "platformAutomerge": true,
+  "postUpdateOptions": ["gomodTidy", "gomodUpdateImportPaths", "pnpmDedupe"],
   "rebaseWhen": "conflicted",
   "reviewers": ["ykzts"]
 }


### PR DESCRIPTION
## Summary
- disable Renovate updates for golang-version in gomod
- keep go 1.24.0 pinned in go.mod for CI minimum-version compatibility

## Background
Renovate was automatically raising the go directive (e.g. 1.24.0 -> 1.25.0), which conflicts with our CI policy to support Go 1.24 through 1.26 while keeping go.mod pinned at 1.24.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go module dependency management configuration with new handling rules disabled by default while preserving existing automation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->