### PR TITLE
chore: add `copilot-setup-steps.yml`

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,41 @@
+name: "Copilot Setup Steps"
+
+# Automatically run the setup steps when they are changed to allow for easy validation, and
+# allow manual testing through the repository's "Actions" tab
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
+  copilot-setup-steps:
+    runs-on: ubuntu-24.04
+
+    # Set the permissions to the lowest permissions possible needed for your steps.
+    # Copilot will be given its own token for its operations.
+    permissions:
+      # If you want to clone the repository as part of your setup steps, for example to install dependencies, you'll need the `contents: read` permission.
+      # If you don't clone the repository in your setup steps, Copilot will do this for you automatically after the steps complete.
+      contents: read
+
+    # You can define any steps you want, and they will run before the agent starts.
+    # If you do not check out your code, Copilot will do this for you.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          go-version: '1.26'
+
+      - name: Get dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libvips-dev libheif-plugin-aomenc
+          go mod download


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow file to automate and validate the Copilot setup steps. The workflow ensures that any changes to the setup process are tested automatically and can also be manually triggered for testing.

**New Copilot setup workflow:**

* Added `.github/workflows/copilot-setup-steps.yml` to define a new workflow named "Copilot Setup Steps" that runs on pushes or pull requests affecting this file, as well as via manual dispatch.
* The workflow includes steps to check out the code, set up Go (version 1.26), and install necessary dependencies (`libvips-dev`, `libheif-plugin-aomenc`) before running `go mod download`.
* Permissions are set to the minimum required, specifically granting `contents: read` for repository access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated GitHub Actions workflow to configure build environment and install required dependencies for development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->