### PR TITLE
build: pin Font Awesome to v6

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,6 +26,11 @@
   },
   "packageRules": [
     {
+      "description": "Keep @fortawesome/fontawesome-free on v6 because Docksy does not support v7 yet",
+      "matchPackageNames": ["@fortawesome/fontawesome-free"],
+      "allowedVersions": "<7"
+    },
+    {
       "description": "Keep go.mod language version pinned for CI floor",
       "enabled": false,
       "matchDatasources": ["golang-version"],


### PR DESCRIPTION
## Summary

- prevent Renovate from updating `@fortawesome/fontawesome-free` to v7
- retain v6 compatibility until Docksy supports Font Awesome v7

## Verification

- Parsed `.github/renovate.json` successfully
- Ran `git diff --check`