### PR TITLE
feat: pass request to post processor

### DIFF
--- a/options.go
+++ b/options.go
@@ -20,6 +20,8 @@
 
 package manael
 
+import "net/http"
+
 // ProxyOptions holds configuration for a proxy created by NewServeProxy.
 type ProxyOptions struct {
 	// EnableAVIF enables AVIF encoding for JPEG images when the client supports it.
@@ -55,6 +57,11 @@ type ProxyOptions struct {
 	// must return the final bytes to be sent to the client. If PostProcessor
 	// returns an error the original unconverted response is passed through.
 	PostProcessor func(data []byte) ([]byte, error)
+	// RequestPostProcessor is an optional hook invoked with the inbound request
+	// and converted image bytes after a successful format conversion. When set,
+	// it takes precedence over PostProcessor. If RequestPostProcessor returns an
+	// error the original unconverted response is passed through.
+	RequestPostProcessor func(r *http.Request, data []byte) ([]byte, error)
 }
 
 // ProxyOption is a functional option for configuring a proxy.
@@ -145,5 +152,17 @@ func WithDefaultQuality(q int) ProxyOption {
 func WithPostProcessor(f func(data []byte) ([]byte, error)) ProxyOption {
 	return func(o *ProxyOptions) {
 		o.PostProcessor = f
+	}
+}
+
+// WithRequestPostProcessor returns a ProxyOption that registers a hook to be
+// invoked with the inbound request and converted image bytes after a successful
+// format conversion. The hook may inspect request-scoped state and modify or
+// replace the byte slice. If the hook returns an error the original
+// unconverted response is passed through unchanged. This hook takes precedence
+// over a PostProcessor configured with WithPostProcessor.
+func WithRequestPostProcessor(f func(r *http.Request, data []byte) ([]byte, error)) ProxyOption {
+	return func(o *ProxyOptions) {
+		o.RequestPostProcessor = f
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -552,6 +552,63 @@ func TestNewServeProxy_postProcessor(t *testing.T) {
 		}
 	})
 
+	t.Run("request hook receives inbound request", func(t *testing.T) {
+		var gotRequest *http.Request
+		sentinel := []byte("request processed")
+
+		p := manael.NewServeProxy(u, manael.WithRequestPostProcessor(func(r *http.Request, data []byte) ([]byte, error) {
+			gotRequest = r
+			return sentinel, nil
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "https://manael.test/photo.jpeg?cache=key", nil)
+		req.Header.Set("Accept", "image/webp,image/*,*/*;q=0.8")
+
+		w := httptest.NewRecorder()
+		p.ServeHTTP(w, req)
+
+		if gotRequest == nil {
+			t.Fatal("RequestPostProcessor was not called")
+		}
+		if got, want := gotRequest.URL.Path, req.URL.Path; got != want {
+			t.Errorf("request path = %q, want %q", got, want)
+		}
+		if got, want := gotRequest.URL.RawQuery, req.URL.RawQuery; got != want {
+			t.Errorf("request query = %q, want %q", got, want)
+		}
+		if got, want := w.Body.Bytes(), sentinel; string(got) != string(want) {
+			t.Errorf("body = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("request hook takes precedence over post processor", func(t *testing.T) {
+		postProcessorCalled := false
+		requestSentinel := []byte("request processed")
+
+		p := manael.NewServeProxy(u,
+			manael.WithPostProcessor(func(data []byte) ([]byte, error) {
+				postProcessorCalled = true
+				return []byte("post processed"), nil
+			}),
+			manael.WithRequestPostProcessor(func(r *http.Request, data []byte) ([]byte, error) {
+				return requestSentinel, nil
+			}),
+		)
+
+		req := httptest.NewRequest(http.MethodGet, "https://manael.test/photo.jpeg", nil)
+		req.Header.Set("Accept", "image/webp,image/*,*/*;q=0.8")
+
+		w := httptest.NewRecorder()
+		p.ServeHTTP(w, req)
+
+		if postProcessorCalled {
+			t.Error("PostProcessor was called despite RequestPostProcessor being configured")
+		}
+		if got, want := w.Body.Bytes(), requestSentinel; string(got) != string(want) {
+			t.Errorf("body = %q, want %q", got, want)
+		}
+	})
+
 	t.Run("hook not called when no conversion happens", func(t *testing.T) {
 		called := false
 

--- a/proxy.go
+++ b/proxy.go
@@ -193,8 +193,13 @@ func modifyResponse(res *http.Response, opts *ProxyOptions) error {
 	}
 
 	outData := buf.Bytes()
-	if opts.PostProcessor != nil {
-		processed, err := opts.PostProcessor(outData)
+	if opts.RequestPostProcessor != nil || opts.PostProcessor != nil {
+		var processed []byte
+		if opts.RequestPostProcessor != nil {
+			processed, err = opts.RequestPostProcessor(res.Request, outData)
+		} else {
+			processed, err = opts.PostProcessor(outData)
+		}
 		if err != nil {
 			res.Body = struct {
 				io.Reader

--- a/website/content/en/docs/usage/post-processing.md
+++ b/website/content/en/docs/usage/post-processing.md
@@ -3,7 +3,7 @@ title: Post-processing Hook
 weight: 55
 ---
 
-Manael v3.1 adds a Go API hook for custom processing after image conversion. Use `WithPostProcessor` when you embed Manael as a library and need to inspect, cache, replace, or augment the converted bytes before they are sent to the client.
+Manael v3.1 adds Go API hooks for custom processing after image conversion. Use `WithPostProcessor` when you embed Manael as a library and need to inspect, cache, replace, or augment the converted bytes before they are sent to the client. Use `WithRequestPostProcessor` when that processing also needs request-scoped state.
 
 ## When the hook runs {#when-it-runs}
 
@@ -25,6 +25,22 @@ proxy := manael.NewServeProxy(upstreamURL,
 )
 ```
 
+## Request-aware processing {#request-aware-processing}
+
+`WithRequestPostProcessor` receives the request together with the converted bytes. Use it to derive a cache key from the request URL or headers, or to apply processing that depends on the caller.
+
+```go
+proxy := manael.NewServeProxy(upstreamURL,
+	manael.WithRequestPostProcessor(func(r *http.Request, data []byte) ([]byte, error) {
+		cacheKey := r.URL.String() + ":" + r.Header.Get("Accept")
+		_ = cacheKey // Use the key with your cache or other request-scoped logic.
+		return data, nil
+	}),
+)
+```
+
+When both hooks are configured, `WithRequestPostProcessor` takes precedence and `WithPostProcessor` is not called.
+
 ## Common use cases {#use-cases}
 
 - Store converted images in an external cache.
@@ -40,3 +56,4 @@ If the hook returns an error, Manael logs the failure and falls back to the orig
 - The hook is a library API, not a command-line option or environment variable.
 - The hook runs after format conversion, so it sees the final converted payload.
 - If no conversion happens for the request, the hook is skipped.
+- If request-scoped state is needed, use `WithRequestPostProcessor`.

--- a/website/content/ja/docs/usage/post-processing.md
+++ b/website/content/ja/docs/usage/post-processing.md
@@ -3,7 +3,7 @@ title: ポストプロセッサーフック
 weight: 55
 ---
 
-Manael v3.1 では、画像変換の後段で独自処理を差し込める Go API フックが追加されました。Manael をライブラリとして組み込み、変換済みバイト列を送信前に確認、キャッシュ、置換、加工したい場合は `WithPostProcessor` を使用します。
+Manael v3.1 では、画像変換の後段で独自処理を差し込める Go API フックが追加されました。Manael をライブラリとして組み込み、変換済みバイト列を送信前に確認、キャッシュ、置換、加工したい場合は `WithPostProcessor` を使用します。リクエスト単位の状態も必要な場合は `WithRequestPostProcessor` を使用します。
 
 ## フックが実行されるタイミング {#when-it-runs}
 
@@ -25,6 +25,22 @@ proxy := manael.NewServeProxy(upstreamURL,
 )
 ```
 
+## リクエスト対応の処理 {#request-aware-processing}
+
+`WithRequestPostProcessor` は、変換済みバイト列とともにリクエストを受け取ります。リクエスト URL やヘッダーからキャッシュキーを作成する場合や、呼び出し元に応じた処理を行う場合に使用してください。
+
+```go
+proxy := manael.NewServeProxy(upstreamURL,
+	manael.WithRequestPostProcessor(func(r *http.Request, data []byte) ([]byte, error) {
+		cacheKey := r.URL.String() + ":" + r.Header.Get("Accept")
+		_ = cacheKey // キャッシュなどのリクエスト単位の処理に使用します。
+		return data, nil
+	}),
+)
+```
+
+両方のフックを設定した場合は `WithRequestPostProcessor` が優先され、`WithPostProcessor` は呼び出されません。
+
 ## 主なユースケース {#use-cases}
 
 - 変換済み画像を外部キャッシュへ保存する。
@@ -40,3 +56,4 @@ proxy := manael.NewServeProxy(upstreamURL,
 - このフックはコマンドラインオプションや環境変数ではなく、Go ライブラリ向け API です。
 - フックはフォーマット変換後に実行されるため、最終的な変換済みペイロードを扱います。
 - リクエストで変換が発生しなかった場合、フックは実行されません。
+- リクエスト単位の状態が必要な場合は `WithRequestPostProcessor` を使用します。


### PR DESCRIPTION
## Summary

- add a request-aware post-processing hook for converted images
- prefer `RequestPostProcessor` when both post-processing hooks are configured
- document request-aware processing in English and Japanese
- cover request forwarding and hook precedence

Fixes #1949

## Verification

- `go test ./...`
- `git diff --check`

Assisted-By: Codex:gpt-5.6-terra