### PR TITLE
feat: add response header processor

### DIFF
--- a/options.go
+++ b/options.go
@@ -62,6 +62,12 @@ type ProxyOptions struct {
 	// it takes precedence over PostProcessor. If RequestPostProcessor returns an
 	// error the original unconverted response is passed through.
 	RequestPostProcessor func(r *http.Request, data []byte) ([]byte, error)
+	// ResponseHeaderProcessor is an optional hook invoked after the final
+	// converted image bytes and their payload-dependent response headers have
+	// been set. It may use the inbound request and final bytes to add or update
+	// response headers. If ResponseHeaderProcessor returns an error the original
+	// unconverted response is passed through.
+	ResponseHeaderProcessor func(r *http.Request, header http.Header, data []byte) error
 }
 
 // ProxyOption is a functional option for configuring a proxy.
@@ -164,5 +170,16 @@ func WithPostProcessor(f func(data []byte) ([]byte, error)) ProxyOption {
 func WithRequestPostProcessor(f func(r *http.Request, data []byte) ([]byte, error)) ProxyOption {
 	return func(o *ProxyOptions) {
 		o.RequestPostProcessor = f
+	}
+}
+
+// WithResponseHeaderProcessor returns a ProxyOption that registers a hook to
+// be invoked after the final converted image bytes and their payload-dependent
+// response headers have been set. The hook may inspect the inbound request and
+// final bytes, and add or update response headers. If the hook returns an error
+// the original unconverted response is passed through unchanged.
+func WithResponseHeaderProcessor(f func(r *http.Request, header http.Header, data []byte) error) ProxyOption {
+	return func(o *ProxyOptions) {
+		o.ResponseHeaderProcessor = f
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -632,3 +632,88 @@ func TestNewServeProxy_postProcessor(t *testing.T) {
 		}
 	})
 }
+
+// TestNewServeProxy_responseHeaderProcessor verifies that the response-header
+// hook receives the final payload after Manael has set its payload headers.
+func TestNewServeProxy_responseHeaderProcessor(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/photo.jpeg", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Disposition", `attachment; filename="photo.jpeg"`)
+		http.ServeFile(w, r, "testdata/photo.jpeg")
+	})
+
+	ts := httptest.NewServer(mux)
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("can set headers for final payload", func(t *testing.T) {
+		final := []byte("final payload")
+		called := false
+		p := manael.NewServeProxy(u,
+			manael.WithPostProcessor(func([]byte) ([]byte, error) { return final, nil }),
+			manael.WithResponseHeaderProcessor(func(r *http.Request, header http.Header, data []byte) error {
+				called = true
+				if got, want := r.URL.Query().Get("cache"), "key"; got != want {
+					t.Errorf("request query = %q, want %q", got, want)
+				}
+				if got, want := string(data), string(final); got != want {
+					t.Errorf("data = %q, want %q", got, want)
+				}
+				if got, want := header.Get("Content-Type"), "image/webp"; got != want {
+					t.Errorf("Content-Type = %q, want %q", got, want)
+				}
+				if got, want := header.Get("Content-Length"), strconv.Itoa(len(final)); got != want {
+					t.Errorf("Content-Length = %q, want %q", got, want)
+				}
+				if got, want := header.Get("Content-Disposition"), `attachment; filename=photo.webp`; got != want {
+					t.Errorf("Content-Disposition = %q, want %q", got, want)
+				}
+				header.Set("ETag", `"final"`)
+				return nil
+			}),
+		)
+
+		req := httptest.NewRequest(http.MethodGet, "https://manael.test/photo.jpeg?cache=key", nil)
+		req.Header.Set("Accept", "image/webp")
+		w := httptest.NewRecorder()
+		p.ServeHTTP(w, req)
+
+		if !called {
+			t.Error("ResponseHeaderProcessor was not called")
+		}
+		if got, want := w.Body.Bytes(), final; string(got) != string(want) {
+			t.Errorf("body = %q, want %q", got, want)
+		}
+		if got, want := w.Header().Get("ETag"), `"final"`; got != want {
+			t.Errorf("ETag = %q, want %q", got, want)
+		}
+		if got, want := w.Header().Get("Content-Length"), strconv.Itoa(len(final)); got != want {
+			t.Errorf("Content-Length = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("hook error falls back to original response", func(t *testing.T) {
+		p := manael.NewServeProxy(u, manael.WithResponseHeaderProcessor(func(_ *http.Request, header http.Header, _ []byte) error {
+			header.Set("ETag", `"should-not-be-sent"`)
+			return errors.New("response-header processor error")
+		}))
+
+		req := httptest.NewRequest(http.MethodGet, "https://manael.test/photo.jpeg", nil)
+		req.Header.Set("Accept", "image/webp")
+		w := httptest.NewRecorder()
+		p.ServeHTTP(w, req)
+
+		resp := w.Result()
+		defer resp.Body.Close()
+		if got, want := resp.Header.Get("Content-Type"), "image/jpeg"; got != want {
+			t.Errorf("Content-Type = %q, want %q", got, want)
+		}
+		if got := resp.Header.Get("ETag"); got != "" {
+			t.Errorf("ETag = %q, want empty", got)
+		}
+	})
+}

--- a/proxy.go
+++ b/proxy.go
@@ -219,6 +219,7 @@ func modifyResponse(res *http.Response, opts *ProxyOptions) error {
 		outData = processed
 	}
 
+	originalHeader := res.Header.Clone()
 	res.Body = io.NopCloser(bytes.NewReader(outData))
 
 	res.Header.Set("Content-Type", typ)
@@ -228,6 +229,26 @@ func modifyResponse(res *http.Response, opts *ProxyOptions) error {
 
 	if res.Header.Get("Accept-Ranges") != "" {
 		res.Header.Del("Accept-Ranges")
+	}
+
+	if opts.ResponseHeaderProcessor != nil {
+		if err := opts.ResponseHeaderProcessor(res.Request, res.Header, outData); err != nil {
+			res.Body = struct {
+				io.Reader
+				io.Closer
+			}{
+				Reader: io.MultiReader(bytes.NewReader(p.Bytes()), origBody),
+				Closer: origBody,
+			}
+			res.Header = originalHeader
+			closeOrigBody = false
+			slog.Error("response-header processor failed",
+				slog.String("error", err.Error()),
+				slog.String("url", res.Request.URL.String()),
+			)
+
+			return nil
+		}
 	}
 
 	return nil

--- a/website/content/en/docs/usage/post-processing.md
+++ b/website/content/en/docs/usage/post-processing.md
@@ -41,11 +41,28 @@ proxy := manael.NewServeProxy(upstreamURL,
 
 When both hooks are configured, `WithRequestPostProcessor` takes precedence and `WithPostProcessor` is not called.
 
+## Response headers for the final payload {#response-headers}
+
+`WithResponseHeaderProcessor` receives the inbound request, response headers, and final converted bytes. Use it to add metadata that depends on the final payload, such as an `ETag`, a cache policy, or an audit header. It cannot replace the payload.
+
+Manael calls this hook after it has selected the final bytes and set `Content-Type`, `Content-Length`, and `Content-Disposition` for them.
+
+```go
+proxy := manael.NewServeProxy(upstreamURL,
+	manael.WithResponseHeaderProcessor(func(r *http.Request, header http.Header, data []byte) error {
+		header.Set("ETag", `"`+strconv.FormatInt(int64(len(data)), 10)+`"`)
+		header.Set("Cache-Control", "private, max-age=60")
+		return nil
+	}),
+)
+```
+
 ## Common use cases {#use-cases}
 
 - Store converted images in an external cache.
 - Add application-specific response processing after format conversion.
 - Integrate with downstream systems that need the final converted payload.
+- Set response metadata derived from the final converted payload.
 
 ## Error handling {#error-handling}
 
@@ -57,3 +74,4 @@ If the hook returns an error, Manael logs the failure and falls back to the orig
 - The hook runs after format conversion, so it sees the final converted payload.
 - If no conversion happens for the request, the hook is skipped.
 - If request-scoped state is needed, use `WithRequestPostProcessor`.
+- Use `WithResponseHeaderProcessor` when custom response headers depend on the final payload.

--- a/website/content/ja/docs/usage/post-processing.md
+++ b/website/content/ja/docs/usage/post-processing.md
@@ -41,11 +41,28 @@ proxy := manael.NewServeProxy(upstreamURL,
 
 両方のフックを設定した場合は `WithRequestPostProcessor` が優先され、`WithPostProcessor` は呼び出されません。
 
+## 最終ペイロードのレスポンスヘッダー {#response-headers}
+
+`WithResponseHeaderProcessor` は、受信したリクエスト、レスポンスヘッダー、および最終的な変換済みバイト列を受け取ります。`ETag`、キャッシュポリシー、監査用ヘッダーなど、最終ペイロードに依存するメタデータを追加する場合に使用します。このフックでペイロードを置き換えることはできません。
+
+Manael は最終バイト列を決定し、それに対応する `Content-Type`、`Content-Length`、`Content-Disposition` を設定した後に、このフックを呼び出します。
+
+```go
+proxy := manael.NewServeProxy(upstreamURL,
+	manael.WithResponseHeaderProcessor(func(r *http.Request, header http.Header, data []byte) error {
+		header.Set("ETag", `"`+strconv.FormatInt(int64(len(data)), 10)+`"`)
+		header.Set("Cache-Control", "private, max-age=60")
+		return nil
+	}),
+)
+```
+
 ## 主なユースケース {#use-cases}
 
 - 変換済み画像を外部キャッシュへ保存する。
 - フォーマット変換後にアプリケーション固有の後処理を行う。
 - 最終的な変換結果を必要とする下流システムへ連携する。
+- 最終的な変換済みペイロードから導出したレスポンスメタデータを設定する。
 
 ## エラーハンドリング {#error-handling}
 
@@ -57,3 +74,4 @@ proxy := manael.NewServeProxy(upstreamURL,
 - フックはフォーマット変換後に実行されるため、最終的な変換済みペイロードを扱います。
 - リクエストで変換が発生しなかった場合、フックは実行されません。
 - リクエスト単位の状態が必要な場合は `WithRequestPostProcessor` を使用します。
+- 最終ペイロードに依存する独自のレスポンスヘッダーには `WithResponseHeaderProcessor` を使用します。


### PR DESCRIPTION
## Summary

- add a response-header processor hook for final converted payloads
- run the hook after Manael has set payload-dependent headers
- fall back to the original upstream response if the hook fails
- document the hook and its ordering in English and Japanese
- cover header mutation, hook ordering, content length, and error handling

Closes #1961

## Testing

- go test ./...
- go vet ./...
- website build attempted (blocked by the repository's pre-existing Hugo npm dependency sync check)