### PR TITLE
docs(website): add v3.2 release blog

### DIFF
--- a/website/content/en/blog/2026-08-23-manael-v3-2-release.md
+++ b/website/content/en/blog/2026-08-23-manael-v3-2-release.md
@@ -1,0 +1,49 @@
+---
+title: "Manael v3.2 is here!"
+date: 2026-08-23
+description: "Manael v3.2 adds request-aware post-processing and response-header customization based on the final payload."
+---
+
+## Overview
+
+Manael v3.2 expands the post-processing hooks available to applications that embed Manael as a Go library. You can now inspect the incoming request while processing converted images and customize response headers based on the final converted payload.
+
+## Request-aware post-processing
+
+The new `WithRequestPostProcessor` receives the incoming `*http.Request` alongside the converted image bytes. It is useful when you need to generate cache keys from the request URL or `Accept` header, or apply processing specific to the caller.
+
+```go
+proxy := manael.NewServeProxy(upstreamURL,
+	manael.WithRequestPostProcessor(func(r *http.Request, data []byte) ([]byte, error) {
+		cacheKey := r.URL.String() + ":" + r.Header.Get("Accept")
+		_ = cacheKey // Use this for request-scoped work such as caching.
+		return data, nil
+	}),
+)
+```
+
+When both `WithRequestPostProcessor` and the existing `WithPostProcessor` are configured, the request-aware hook takes precedence.
+
+## Response headers based on the final payload
+
+`WithResponseHeaderProcessor` receives the incoming request, response headers, and final converted bytes. Use it to set metadata derived from the final payload, such as `ETag`, cache policy, or audit headers. This hook cannot replace the payload itself.
+
+Manael invokes the hook after it has determined the final bytes and set `Content-Type`, `Content-Length`, and `Content-Disposition`.
+
+```go
+proxy := manael.NewServeProxy(upstreamURL,
+	manael.WithResponseHeaderProcessor(func(r *http.Request, header http.Header, data []byte) error {
+		header.Set("ETag", `"`+strconv.FormatInt(int64(len(data)), 10)+`"`)
+		header.Set("Cache-Control", "private, max-age=60")
+		return nil
+	}),
+)
+```
+
+## Safe fallback behavior
+
+These hooks only run when Manael actually converts an image. If no conversion happens, they are skipped. If either hook returns an error, Manael logs the failure and safely falls back to the original upstream response instead of returning a partially processed result.
+
+## Learn more
+
+See the post-processing hook documentation and check the release notes for the full change set in v3.2.

--- a/website/content/ja/blog/2026-08-23-manael-v3-2-release.md
+++ b/website/content/ja/blog/2026-08-23-manael-v3-2-release.md
@@ -1,0 +1,49 @@
+---
+title: "Manael v3.2 リリース！"
+date: 2026-08-23
+description: "Manael v3.2 では、リクエスト情報を利用した後処理と、最終ペイロードに基づくレスポンスヘッダーのカスタマイズを追加しました。"
+---
+
+## 概要
+
+Manael v3.2 では、Go ライブラリとして組み込むアプリケーション向けのポストプロセッサーフックを拡張しました。変換済み画像の後処理で受信リクエストを参照できるようになり、最終的な変換結果に基づいてレスポンスヘッダーをカスタマイズすることもできます。
+
+## リクエスト情報を利用する後処理
+
+新しい `WithRequestPostProcessor` は、変換済み画像のバイト列に加えて、受信した `*http.Request` を受け取ります。リクエスト URL や `Accept` ヘッダーを使ってキャッシュキーを生成したり、呼び出し元に応じて処理を変えたりする場合に便利です。
+
+```go
+proxy := manael.NewServeProxy(upstreamURL,
+	manael.WithRequestPostProcessor(func(r *http.Request, data []byte) ([]byte, error) {
+		cacheKey := r.URL.String() + ":" + r.Header.Get("Accept")
+		_ = cacheKey // キャッシュなどのリクエスト単位の処理に使用します。
+		return data, nil
+	}),
+)
+```
+
+`WithRequestPostProcessor` と従来の `WithPostProcessor` を両方設定した場合は、前者が優先されます。
+
+## 最終ペイロードに基づくレスポンスヘッダー
+
+`WithResponseHeaderProcessor` は、受信リクエスト、レスポンスヘッダー、最終的な変換済みバイト列を受け取るフックです。`ETag`、キャッシュポリシー、監査用ヘッダーなど、最終ペイロードから導出するメタデータを設定できます。このフックでペイロード自体を置き換えることはできません。
+
+Manael は、最終バイト列を決定して `Content-Type`、`Content-Length`、`Content-Disposition` を設定した後に、このフックを呼び出します。
+
+```go
+proxy := manael.NewServeProxy(upstreamURL,
+	manael.WithResponseHeaderProcessor(func(r *http.Request, header http.Header, data []byte) error {
+		header.Set("ETag", `"`+strconv.FormatInt(int64(len(data)), 10)+`"`)
+		header.Set("Cache-Control", "private, max-age=60")
+		return nil
+	}),
+)
+```
+
+## 安全なフォールバック動作
+
+これらのフックは、Manael が実際に画像を変換した場合にのみ実行されます。変換が発生しなければフックはスキップされます。いずれかのフックがエラーを返した場合は、Manael が失敗をログ出力し、加工途中の結果ではなく元のアップストリームレスポンスへ安全にフォールバックします。
+
+## 詳細
+
+ポストプロセッサーフックのドキュメントと、v3.2 の変更内容をあわせて確認してください。


### PR DESCRIPTION
### Description

- Add Japanese and English release blog posts for Manael v3.2.
- Document request-aware post-processing and response-header processing hooks.
- Describe hook precedence and safe fallback behavior.

### Related Issue

N/A

### Checklist

- [ ] I have run `go test ./...` and all tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have run `pnpm --dir website build` successfully.